### PR TITLE
学習進捗によるデータの紐づけ

### DIFF
--- a/src/main/java/com/example/learning_progress/controller/ProgressLogController.java
+++ b/src/main/java/com/example/learning_progress/controller/ProgressLogController.java
@@ -2,8 +2,11 @@ package com.example.learning_progress.controller;
 
 import java.net.URI;
 import java.util.List;
+import java.util.Objects;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -12,32 +15,60 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.example.learning_progress.entity.LearningGoal;
 import com.example.learning_progress.entity.ProgressLog;
+import com.example.learning_progress.entity.User;
+import com.example.learning_progress.service.LearningGoalService;
 import com.example.learning_progress.service.ProgressLogService;
+import com.example.learning_progress.service.UserService;
 
 @RestController
 @RequestMapping("/api/progress")
 public class ProgressLogController {
 
-	/**
-	 * 学習進捗サービス
-	 */
 	private final ProgressLogService logService;
+	private final UserService userService;
+	private final LearningGoalService goalService;
 
 	/**
 	 * コンストラクタ
-	 * @param logService 学習進捗サービス
 	 */
-	public ProgressLogController(ProgressLogService logService) {
+	ProgressLogController(ProgressLogService logService, UserService userService, LearningGoalService goalService) {
 		this.logService = logService;
+		this.userService = userService;
+		this.goalService = goalService;
 	}
 
+	/**
+	 * 学習記録を追加する
+	 */
 	@PostMapping
-	public ResponseEntity<ProgressLog> addLog(@RequestBody ProgressLog log) {
+	public ResponseEntity<?> addLog(@RequestBody ProgressLog log) {
+
+		// ログイン認証済みユーザーのユーザー名を取得する
+		String username = SecurityContextHolder.getContext().getAuthentication().getName();
+
+		// ユーザ名を検索し、ユーザー情報を取得する。存在しない場合、例外をスローする。
+		User user = userService.findByUsername(username)
+				.orElseThrow(() -> new RuntimeException("User not found"));
+
+		// 対象の目標がログインユーザーのものであることを検証する
+		LearningGoal goal = goalService.findById(log.getGoal().getId())
+				.orElseThrow(() -> new RuntimeException("Goal not found"));
+
+		// 学習目標のIDが認証済みユーザーのIDと一致しない場合
+		if (!Objects.equals(goal.getUser().getId(), user.getId())) {
+
+			// 例外をスローする
+			return ResponseEntity.status(HttpStatus.FORBIDDEN).body("他人の目標には記録できません");
+		}
+
+		// 学習目標を設定する
+		log.setGoal(goal);
 
 		// サービス層の保存処理を実行し、保存した学習進捗情報を取得する
 		ProgressLog saved = logService.addProgress(log);
-		
+
 		// 新しく作成されたリソースの場所（URI）をヘッダーに記述する
 		URI location = URI.create("/api/progress/" + saved.getId());
 
@@ -45,8 +76,29 @@ public class ProgressLogController {
 		return ResponseEntity.created(location).body(saved);
 	}
 
+	/**
+	 * 自分の目標の記録のみ取得する
+	 */
 	@GetMapping("/goal/{goalId}")
-	public ResponseEntity<List<ProgressLog>> getLogs(@PathVariable Long goalId) {
+	public ResponseEntity<?> getLogs(@PathVariable Long goalId) {
+
+		// ログイン認証済みユーザーのユーザー名を取得する
+		String username = SecurityContextHolder.getContext().getAuthentication().getName();
+
+		// ユーザ名を検索し、ユーザー情報を取得する。存在しない場合、例外をスローする。
+		User user = userService.findByUsername(username)
+				.orElseThrow(() -> new RuntimeException("User not found"));
+
+		// 対象の目標がログインユーザーのものであることを検証する
+		LearningGoal goal = goalService.findById(goalId)
+				.orElseThrow(() -> new RuntimeException("Goal not found"));
+
+		// 学習目標のIDが認証済みユーザーのIDと一致しない場合
+		if (!Objects.equals(goal.getUser().getId(), user.getId())) {
+
+			// 例外をスローする
+			return ResponseEntity.status(HttpStatus.FORBIDDEN).body("他人の目標には記録できません");
+		}
 
 		// サービス層の処理を実行し、IDから学習進捗一覧を取得する
 		List<ProgressLog> goals = logService.getLogsByGoalId(goalId);
@@ -57,10 +109,10 @@ public class ProgressLogController {
 
 	@DeleteMapping("/{logId}")
 	public ResponseEntity<Void> deleteLog(@PathVariable Long logId) {
-		
+
 		// サービス層の処理を実行し、対象の学習進捗情報を消去する
 		logService.deleteLog(logId);
-		
+
 		// 「204 No Content」データなし、成功を返却する
 		return ResponseEntity.noContent().build();
 	}


### PR DESCRIPTION
## 概要
ログイン中のユーザーに紐づいた学習目標にのみ記録を登録・取得できるようにしました。

## 実装内容
- SecurityContextHolderクラスを使用し、ログイン中のユーザー名を取得
- "/api/progress" ログイン中ユーザーに学習記録を追加（POST）
- "/api/progress/goal/{goalId}" 自分の学習記録を取得（GET）

## 備考
- テストユーザー: alice@example.com / password123
- テスト結果 : 学習記録の追加、自分の目標の記録のみ取得成功