### PR TITLE
ロール権限を追加

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,6 +91,13 @@
 			<artifactId>mysql-connector-j</artifactId>
 			<scope>runtime</scope>
 		</dependency>
+		
+		<!-- OpenAPIの導入 -->
+		<dependency>
+		  <groupId>org.springdoc</groupId>
+		  <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+		  <version>2.5.0</version> <!-- ※最新安定版推奨 -->
+		</dependency>
 
 	</dependencies>
 

--- a/src/main/java/com/example/learning_progress/DataInitializer.java
+++ b/src/main/java/com/example/learning_progress/DataInitializer.java
@@ -2,6 +2,7 @@ package com.example.learning_progress;
 
 import java.time.LocalDate;
 import java.util.Optional;
+import java.util.Set;
 
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.context.annotation.Bean;
@@ -33,6 +34,19 @@ public class DataInitializer {
 
 			// ユーザーチェック
 			Optional<User> existing = userRepository.findByUsername("alice");
+			
+			Optional<User> existingAdmin = userRepository.findByUsername("admin");
+			
+			// ADMINユーザーがいない場合
+			if (existingAdmin.isEmpty()) {
+				
+				// ADMINユーザー作成
+				User admin = new User();
+				admin.setUsername("admin");
+				admin.setPassword(passwordEncoder.encode("adminpass"));
+				admin.setRoles(Set.of("ADMIN"));
+				userRepository.save(admin);
+			}
 
 			// ユーザーが存在しない場合
 			if (existing.isEmpty()) {
@@ -41,6 +55,7 @@ public class DataInitializer {
 				User alice = new User();
 				alice.setUsername("alice");
 				alice.setPassword(passwordEncoder.encode("password123"));
+				alice.setRoles(Set.of("USER"));
 				userRepository.save(alice);
 
 				// 学習目標作成

--- a/src/main/java/com/example/learning_progress/config/SecurityConfig.java
+++ b/src/main/java/com/example/learning_progress/config/SecurityConfig.java
@@ -47,6 +47,8 @@ public class SecurityConfig {
 				.csrf(csrf -> csrf.disable()) // CSRF不要のため無効化
 				.authorizeHttpRequests(auth -> auth
 						.requestMatchers("/api/auth/**", "/api/users").permitAll() // 指定パスの認証を不要
+						.requestMatchers("/api/admin/**").hasRole("ADMIN") // 管理者専用
+						.requestMatchers("/api/goals/**", "/api/progress/**").hasAnyRole("USER", "ADMIN")
 						.anyRequest().authenticated() // それ以外は認証が必要
 				)
 				.sessionManagement(sess -> sess.sessionCreationPolicy(SessionCreationPolicy.STATELESS)) // トークンを前提とし、セッションを使用しない

--- a/src/main/java/com/example/learning_progress/controller/AdminController.java
+++ b/src/main/java/com/example/learning_progress/controller/AdminController.java
@@ -1,0 +1,53 @@
+package com.example.learning_progress.controller;
+
+import java.util.List;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.example.learning_progress.entity.LearningGoal;
+import com.example.learning_progress.entity.ProgressLog;
+import com.example.learning_progress.entity.User;
+import com.example.learning_progress.service.LearningGoalService;
+import com.example.learning_progress.service.ProgressLogService;
+import com.example.learning_progress.service.UserService;
+
+@RestController
+@RequestMapping("/api/admin")
+public class AdminController {
+
+	private final UserService userService;
+	private final LearningGoalService goalService;
+	private final ProgressLogService logService;
+
+	public AdminController(UserService userService, LearningGoalService goalService, ProgressLogService logService) {
+		this.userService = userService;
+		this.goalService = goalService;
+		this.logService = logService;
+	}
+
+	/**
+	 * 管理者のみ全ユーザーを取得する
+	 */
+	@GetMapping("/users")
+	public List<User> getAllUsers() {
+		return userService.findAll();
+	}
+
+	/**
+	 * 管理者のみ全学習目標を取得する
+	 */
+	@GetMapping("/goals")
+	public List<LearningGoal> getAllGoals() {
+		return goalService.findAll();
+	}
+
+	/**
+	 * 管理者のみ全学習状況を取得する
+	 */
+	@GetMapping("/logs")
+	public List<ProgressLog> getAllLogs() {
+		return logService.findAll();
+	}
+}

--- a/src/main/java/com/example/learning_progress/entity/User.java
+++ b/src/main/java/com/example/learning_progress/entity/User.java
@@ -1,15 +1,21 @@
 package com.example.learning_progress.entity;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import com.fasterxml.jackson.annotation.JsonManagedReference;
 
 import jakarta.persistence.CascadeType;
+import jakarta.persistence.CollectionTable;
 import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 
@@ -38,6 +44,14 @@ public class User {
 	 */
 	@Column(nullable = false)
 	private String password;
+
+	/**
+	 * 権限
+	 */
+	@ElementCollection(fetch = FetchType.EAGER)
+	@CollectionTable(name = "user_roles", joinColumns = @JoinColumn(name = "user_id"))
+	@Column(name = "role")
+	private Set<String> roles = new HashSet<>();
 
 	/**
 	 * 学習目標
@@ -98,6 +112,22 @@ public class User {
 	 */
 	public void setPassword(String password) {
 		this.password = password;
+	}
+
+	/**
+	 * 権限を取得する
+	 * @return roles
+	 */
+	public Set<String> getRoles() {
+		return roles;
+	}
+
+	/**
+	 * 権限を設定する
+	 * @param password 権限
+	 */
+	public void setRoles(Set<String> roles) {
+		this.roles = roles;
 	}
 
 	/**

--- a/src/main/java/com/example/learning_progress/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/learning_progress/security/JwtAuthenticationFilter.java
@@ -72,8 +72,13 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 				}
 			}
 		}
-
-		// チェーン内の次のフィルターやコントローラへリクエストを渡す
-		filterChain.doFilter(request, response);
+		
+		// トークンが無いまたは、不正な形式の場合
+		if (authHeader == null || !authHeader.startsWith(TOKEN_PREFIX)) {
+			
+			// チェーン内の次のフィルターやコントローラへリクエストを渡す
+		    filterChain.doFilter(request, response);
+		    return;
+		}
 	}
 }

--- a/src/main/java/com/example/learning_progress/security/UserDetailsImpl.java
+++ b/src/main/java/com/example/learning_progress/security/UserDetailsImpl.java
@@ -1,9 +1,10 @@
 package com.example.learning_progress.security;
 
 import java.util.Collection;
-import java.util.List;
+import java.util.stream.Collectors;
 
 import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
 import com.example.learning_progress.entity.User;
@@ -20,11 +21,13 @@ public class UserDetailsImpl implements UserDetails {
 	}
 
 	/**
-	 * 空リストを返却する
+	 * ユーザーのロールを返却する
 	 */
 	@Override
 	public Collection<? extends GrantedAuthority> getAuthorities() {
-		return List.of();
+		return user.getRoles().stream()
+				.map(role -> new SimpleGrantedAuthority("ROLE_" + role))
+				.collect(Collectors.toList());
 	}
 
 	/**

--- a/src/main/java/com/example/learning_progress/service/LearningGoalService.java
+++ b/src/main/java/com/example/learning_progress/service/LearningGoalService.java
@@ -36,16 +36,16 @@ public class LearningGoalService {
 	 * @return 学習目標を保存する
 	 */
 	public LearningGoal createGoalForUser(User user, String title, int targetHours) {
-		
+
 		// 同じ目標がある時、trueを返却する。
 		boolean exists = goalRepository.findByUserId(user.getId()).stream()
 				.anyMatch(g -> g.getTitle().equalsIgnoreCase(title)); // 大文字、小文字を区別しない
-		
+
 		// 同じタイトルが存在する場合、業務例外をスローする
 		if (exists) {
 			throw new BusinessException("同じタイトルの目標は既に存在します", ErrorCode.DUPLICATE_OPERATION);
 		}
-		
+
 		// 新規目標を作成する
 		LearningGoal goal = new LearningGoal();
 		goal.setTitle(title);
@@ -80,5 +80,14 @@ public class LearningGoalService {
 		// 一致する学習目標IDを取得する
 		return goalRepository.findById(id)
 				.orElseThrow(() -> new EntityNotFoundException("指定された学習目標が存在しません"));
+	}
+
+	/**
+	 * 全学習目標取得処理(管理者用)
+	 * 
+	 * @return 学習目標をすべて取得する
+	 */
+	public List<LearningGoal> findAll() {
+		return goalRepository.findAll();
 	}
 }

--- a/src/main/java/com/example/learning_progress/service/ProgressLogService.java
+++ b/src/main/java/com/example/learning_progress/service/ProgressLogService.java
@@ -57,4 +57,13 @@ public class ProgressLogService {
 		// 対象行の進捗情報を消去する
 		logRepository.deleteById(logId);
 	}
+
+	/**
+	 * 全学習状況取得処理
+	 * 
+	 * @return 学習状況をすべて取得する
+	 */
+	public List<ProgressLog> findAll() {
+		return logRepository.findAll();
+	}
 }

--- a/src/main/java/com/example/learning_progress/service/UserService.java
+++ b/src/main/java/com/example/learning_progress/service/UserService.java
@@ -1,5 +1,8 @@
 package com.example.learning_progress.service;
 
+import java.util.List;
+import java.util.Set;
+
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
@@ -7,8 +10,6 @@ import com.example.learning_progress.entity.User;
 import com.example.learning_progress.repository.UserRepository;
 
 import jakarta.persistence.EntityNotFoundException;
-
-
 
 @Service
 public class UserService {
@@ -45,7 +46,20 @@ public class UserService {
 		// パスワードをハッシュ化して保存する
 		user.setPassword(passwordEncoder.encode(user.getPassword()));
 
+		// デフォルトで"USER"を設定する
+		user.setRoles(Set.of("USER"));
+
 		// ユーザーエンティティをデータベースへ登録する
 		return userRepository.save(user);
+	}
+
+	/**
+	 * 
+	 * 全ユーザー情報取得処理（管理者用）
+	 * 
+	 * @return ユーザー情報をすべて返却する
+	 */
+	public List<User> findAll() {
+		return userRepository.findAll();
 	}
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -15,6 +15,10 @@ spring.jpa.database-platform=org.hibernate.dialect.MySQL8Dialect
 # 文字コード対策
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
+# OpenAPI権限（本番では「false」）
+springdoc.swagger-ui.enabled=false
+springdoc.api-docs.enabled=false
+
 # HTTPエンコーディングの設定（新しいプロパティ）
 server.servlet.encoding.charset=UTF-8
 server.servlet.encoding.enabled=true


### PR DESCRIPTION
## 概要
ロールで制御できるよう、管理者（ADMIN）とユーザー（USER）を追加しました。

## 実装内容
- USER：自分の目標、記録のみ登録・取得
- ADMIN：全ユーザーの目標・記録にアクセス 
- 管理者専用のコントローラを作成し、アクセスを制限
- サービス層に管理者用メソッドを追加 

## 備考
- テストユーザー: admin / adminpass